### PR TITLE
Modernize Hampton Roads DevFest Code of Conduct

### DIFF
--- a/hrdevfest-coc.md
+++ b/hrdevfest-coc.md
@@ -6,7 +6,7 @@
 
 <h2>Need Help?</h2>
 
-<p>If you need to report an incident or have any concerns, please contact the organizing team at <a href="mailto:team@hrdevfest.org">team@hrdevfest.org</a>. You can also speak directly with any staff member during the event.</p>
+<p>If you need to report an incident or have any concerns, please contact the organizing team at <a href="mailto:team@revolutionva.org">team@revolutionva.org</a>. You can also speak directly with any staff member during the event.</p>
 
 <h2>The Quick Version</h2>
 
@@ -35,7 +35,7 @@
 
 <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the staff immediately. Hampton Roads DevFest staff can be identified by their designated staff t-shirts and badges.</p>
 
-<p>You can also report incidents by emailing <a href="mailto:team@hrdevfest.org">team@hrdevfest.org</a>. When you make a report, here is what you can expect:</p>
+<p>You can also report incidents by emailing <a href="mailto:team@revolutionva.org">team@revolutionva.org</a>. When you make a report, here is what you can expect:</p>
 <ul>
 <li><strong>Acknowledgment:</strong> Your report will be acknowledged promptly.</li>
 <li><strong>Confidentiality:</strong> All reports will be handled with discretion. Details will only be shared as needed to investigate and resolve the situation.</li>
@@ -55,7 +55,7 @@
 
 <h2>Accessibility</h2>
 
-<p>Hampton Roads DevFest is committed to providing an accessible and inclusive environment for all participants. If you need accommodations to fully participate in the event, please contact us at <a href="mailto:team@hrdevfest.org">team@hrdevfest.org</a> and we will do our best to meet your needs.</p>
+<p>Hampton Roads DevFest is committed to providing an accessible and inclusive environment for all participants. If you need accommodations to fully participate in the event, please contact us at <a href="mailto:team@revolutionva.org">team@revolutionva.org</a> and we will do our best to meet your needs.</p>
 
 <div class="footer">
 <p><small><em>Original source and credit: <a href="https://web.archive.org/web/2012/http://2012.jsconf.us/#/about">JSConf 2012</a> &amp; <a href="https://geekfeminism.fandom.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a><br>

--- a/hrdevfest-coc.md
+++ b/hrdevfest-coc.md
@@ -25,7 +25,6 @@
 <p>If a participant engages in harassing behavior, the conference organisers may take action including but not limited to:</p>
 <ol>
 <li>A verbal warning and request to stop the behavior</li>
-<li>A written warning documenting the incident</li>
 <li>Temporary removal from the event space</li>
 <li>Permanent expulsion from the conference with no refund</li>
 <li>Referral to venue security or local law enforcement</li>

--- a/hrdevfest-coc.md
+++ b/hrdevfest-coc.md
@@ -10,7 +10,7 @@
 
 <h2>The Quick Version</h2>
 
-<p>Hampton Roads DevFest is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), socioeconomic status, immigration or citizenship status, pregnancy, veteran status, neurodiversity, or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, social media (including Twitter/X, Discord, Slack), and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers.</p>
+<p>Hampton Roads DevFest is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), socioeconomic status, immigration or citizenship status, pregnancy, veteran status, neurodiversity, or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, social media (including Twitter/X, Discord, Slack), and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organizers.</p>
 
 <h2>The Less Quick Version</h2>
 
@@ -22,14 +22,14 @@
 
 <h2>Consequences</h2>
 
-<p>If a participant engages in harassing behavior, the conference organisers may take action including but not limited to:</p>
+<p>If a participant engages in harassing behavior, the conference organizers may take action including but not limited to:</p>
 <ol>
 <li>A verbal warning and request to stop the behavior</li>
 <li>Temporary removal from the event space</li>
 <li>Permanent expulsion from the conference with no refund</li>
 <li>Referral to venue security or local law enforcement</li>
 </ol>
-<p>The severity of the response will be determined by the organisers based on the nature and context of the behavior.</p>
+<p>The severity of the response will be determined by the organizers based on the nature and context of the behavior.</p>
 
 <h2>Reporting Process</h2>
 

--- a/hrdevfest-coc.md
+++ b/hrdevfest-coc.md
@@ -6,34 +6,64 @@
 
 <h2>Need Help?</h2>
 
-<p>This conference is co-organized by <a href="https://twitter.com/taylorka">Ken</a>, <a href="https://twitter.com/tealmage">Adam</a>, <a href="https://twitter.com/alexproaps">Alex</a>, <a href="https://twitter.com/keithprivette">Keith</a>, <a href="https://twitter.com/lynnaloo">Linda</a>, and <a href="https://twitter.com/1kevgriff">Kevin</a>. You should have our contact details in the emails we’ve sent prior to the event or you can email all organizers at <a href="mailto:team@hrdevfest.org">team@hrdevfest.org</a>.</p>
+<p>If you need to report an incident or have any concerns, please contact the organizing team at <a href="mailto:team@hrdevfest.org">team@hrdevfest.org</a>. You can also speak directly with any staff member during the event.</p>
 
 <h2>The Quick Version</h2>
 
-<p>Hampton Roads DevFest is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers.</p>
+<p>Hampton Roads DevFest is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), socioeconomic status, immigration or citizenship status, pregnancy, veteran status, neurodiversity, or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, social media (including Twitter/X, Discord, Slack), and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers.</p>
 
 <h2>The Less Quick Version</h2>
 
-<p>Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
+<p>Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, unwelcome sexual attention, doxing or sharing of private information without consent, deliberate misgendering or deadnaming, and threats of violence.</p>
 
 <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
 
 <p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. Booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.</p>
 
-<p>If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.</p>
+<h2>Consequences</h2>
 
-<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the staff immediately. Hampton Roads DevFest staff can be identified as they&#39;ll be wearing staff t-shirts.</p>
+<p>If a participant engages in harassing behavior, the conference organisers may take action including but not limited to:</p>
+<ol>
+<li>A verbal warning and request to stop the behavior</li>
+<li>A written warning documenting the incident</li>
+<li>Temporary removal from the event space</li>
+<li>Permanent expulsion from the conference with no refund</li>
+<li>Referral to venue security or local law enforcement</li>
+</ol>
+<p>The severity of the response will be determined by the organisers based on the nature and context of the behavior.</p>
+
+<h2>Reporting Process</h2>
+
+<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the staff immediately. Hampton Roads DevFest staff can be identified by their designated staff t-shirts and badges.</p>
+
+<p>You can also report incidents by emailing <a href="mailto:team@hrdevfest.org">team@hrdevfest.org</a>. When you make a report, here is what you can expect:</p>
+<ul>
+<li><strong>Acknowledgment:</strong> Your report will be acknowledged promptly.</li>
+<li><strong>Confidentiality:</strong> All reports will be handled with discretion. Details will only be shared as needed to investigate and resolve the situation.</li>
+<li><strong>Investigation:</strong> The organizers will review the report and speak with involved parties as appropriate.</li>
+<li><strong>Outcome:</strong> You will be informed of the resolution. Actions taken will follow the consequences outlined above.</li>
+</ul>
 
 <p>Hampton Roads DevFest staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.</p>
 
-<p>We expect participants to follow these rules at Hampton Roads DevFest venues and conference-related social events.</p>
+<h2>Photography and Recording</h2>
+
+<p>We want everyone to feel comfortable at Hampton Roads DevFest. Please ask for consent before photographing or recording other attendees. If someone asks you not to photograph or record them, please respect their wishes. Official event photographers will be clearly identified; if you prefer not to be photographed, please let them know.</p>
+
+<h2>Applicability</h2>
+
+<p>We expect participants to follow these rules at all Hampton Roads DevFest venues, conference-related social events, and event-specific online platforms (such as Discord, Slack, or other community channels). This code of conduct also applies to interactions between participants after the event if they stem from conduct that occurred during the conference. Continued harassment outside the event will be treated with the same seriousness.</p>
+
+<h2>Accessibility</h2>
+
+<p>Hampton Roads DevFest is committed to providing an accessible and inclusive environment for all participants. If you need accommodations to fully participate in the event, please contact us at <a href="mailto:team@hrdevfest.org">team@hrdevfest.org</a> and we will do our best to meet your needs.</p>
 
 <div class="footer">
-<p><small><em>Original source and credit: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a> &amp; <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a><br>
+<p><small><em>Original source and credit: <a href="https://web.archive.org/web/2012/http://2012.jsconf.us/#/about">JSConf 2012</a> &amp; <a href="https://geekfeminism.fandom.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a><br>
 
-Please help by translating or improving: <a href="https://github.com/leftlogic/confcodeofconduct.com">http://github.com/leftlogic/confcodeofconduct.com</a><br>
+Please help by translating or improving: <a href="https://github.com/leftlogic/confcodeofconduct.com">github.com/leftlogic/confcodeofconduct.com</a><br>
 
-This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a></em></small>
+This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a></em></small>
 
 </p>
 </div>

--- a/hrdevfest-coc.md
+++ b/hrdevfest-coc.md
@@ -58,7 +58,7 @@
 <p>Hampton Roads DevFest is committed to providing an accessible and inclusive environment for all participants. If you need accommodations to fully participate in the event, please contact us at <a href="mailto:team@revolutionva.org">team@revolutionva.org</a> and we will do our best to meet your needs.</p>
 
 <div class="footer">
-<p><small><em>Original source and credit: <a href="https://web.archive.org/web/2012/http://2012.jsconf.us/#/about">JSConf 2012</a> &amp; <a href="https://geekfeminism.fandom.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a><br>
+<p><small><em>Original source and credit: JSConf 2012 &amp; <a href="https://geekfeminism.fandom.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a><br>
 
 Please help by translating or improving: <a href="https://github.com/leftlogic/confcodeofconduct.com">github.com/leftlogic/confcodeofconduct.com</a><br>
 

--- a/hrdevfest-coc.md
+++ b/hrdevfest-coc.md
@@ -43,7 +43,7 @@
 <li><strong>Outcome:</strong> You will be informed of the resolution. Actions taken will follow the consequences outlined above.</li>
 </ul>
 
-<p>Hampton Roads DevFest staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.</p>
+<p>Hampton Roads DevFest staff will be happy to help participants contact venue/event staff or local law enforcement, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.</p>
 
 <h2>Photography and Recording</h2>
 

--- a/hrdevfest-coc.md
+++ b/hrdevfest-coc.md
@@ -18,7 +18,7 @@
 
 <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
 
-<p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. Booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.</p>
+<p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.</p>
 
 <h2>Consequences</h2>
 


### PR DESCRIPTION
## Summary
- Replace individual Twitter organizer links with single `team@revolutionva.org` contact and update social media references from "Twitter" to "social media (including Twitter/X, Discord, Slack)"
- Expand protected categories (socioeconomic status, immigration/citizenship status, pregnancy, veteran status, neurodiversity) and harassment definitions (doxing, deliberate misgendering/deadnaming, threats of violence)
- Add graduated consequences ladder suited for a 1-day event: verbal warning, temporary removal, permanent expulsion, law enforcement referral
- Add detailed reporting process with what to expect
- Add photography/recording consent policy, accessibility statement, and expanded applicability covering online platforms and post-event interactions
- Adjust assistance language for single-day format (venue/event staff, no escorts)
- Fix outdated links: `http` → `https`, `geekfeminism.wikia.com` → `geekfeminism.fandom.com`, remove dead JSConf 2012 link (keep credit as plain text)

## Test plan
- [ ] Open `hrdevfest-coc.md` in a browser and confirm HTML renders correctly
- [ ] Verify all hyperlinks resolve (team email, Geek Feminism wiki, Creative Commons, GitHub repo)
- [ ] Read through for tone consistency and completeness
- [ ] Confirm `revconf-coc.md` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)